### PR TITLE
chore: Migrate redis synth.py to bazel

### DIFF
--- a/grpc-google-cloud-redis-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-redis-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.0.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/redis/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-redis-v1/src/main/java/com/google/cloud/redis/v1/CloudRedisGrpc.java
+++ b/grpc-google-cloud-redis-v1/src/main/java/com/google/cloud/redis/v1/CloudRedisGrpc.java
@@ -41,7 +41,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/redis/v1/cloud_redis.proto")
 public final class CloudRedisGrpc {
 
@@ -50,30 +50,20 @@ public final class CloudRedisGrpc {
   public static final String SERVICE_NAME = "google.cloud.redis.v1.CloudRedis";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListInstancesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.ListInstancesRequest,
-          com.google.cloud.redis.v1.ListInstancesResponse>
-      METHOD_LIST_INSTANCES = getListInstancesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.ListInstancesRequest,
           com.google.cloud.redis.v1.ListInstancesResponse>
       getListInstancesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListInstances",
+      requestType = com.google.cloud.redis.v1.ListInstancesRequest.class,
+      responseType = com.google.cloud.redis.v1.ListInstancesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.ListInstancesRequest,
           com.google.cloud.redis.v1.ListInstancesResponse>
       getListInstancesMethod() {
-    return getListInstancesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.ListInstancesRequest,
-          com.google.cloud.redis.v1.ListInstancesResponse>
-      getListInstancesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.ListInstancesRequest,
             com.google.cloud.redis.v1.ListInstancesResponse>
@@ -88,9 +78,7 @@ public final class CloudRedisGrpc {
                           com.google.cloud.redis.v1.ListInstancesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "ListInstances"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListInstances"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -106,26 +94,18 @@ public final class CloudRedisGrpc {
     return getListInstancesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.GetInstanceRequest, com.google.cloud.redis.v1.Instance>
-      METHOD_GET_INSTANCE = getGetInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.GetInstanceRequest, com.google.cloud.redis.v1.Instance>
       getGetInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetInstance",
+      requestType = com.google.cloud.redis.v1.GetInstanceRequest.class,
+      responseType = com.google.cloud.redis.v1.Instance.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.GetInstanceRequest, com.google.cloud.redis.v1.Instance>
       getGetInstanceMethod() {
-    return getGetInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.GetInstanceRequest, com.google.cloud.redis.v1.Instance>
-      getGetInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.GetInstanceRequest, com.google.cloud.redis.v1.Instance>
         getGetInstanceMethod;
@@ -139,8 +119,7 @@ public final class CloudRedisGrpc {
                           com.google.cloud.redis.v1.Instance>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.redis.v1.CloudRedis", "GetInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -156,26 +135,18 @@ public final class CloudRedisGrpc {
     return getGetInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.CreateInstanceRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_INSTANCE = getCreateInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.CreateInstanceRequest, com.google.longrunning.Operation>
       getCreateInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateInstance",
+      requestType = com.google.cloud.redis.v1.CreateInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.CreateInstanceRequest, com.google.longrunning.Operation>
       getCreateInstanceMethod() {
-    return getCreateInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.CreateInstanceRequest, com.google.longrunning.Operation>
-      getCreateInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.CreateInstanceRequest, com.google.longrunning.Operation>
         getCreateInstanceMethod;
@@ -189,9 +160,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "CreateInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -207,26 +176,18 @@ public final class CloudRedisGrpc {
     return getCreateInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.UpdateInstanceRequest, com.google.longrunning.Operation>
-      METHOD_UPDATE_INSTANCE = getUpdateInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.UpdateInstanceRequest, com.google.longrunning.Operation>
       getUpdateInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateInstance",
+      requestType = com.google.cloud.redis.v1.UpdateInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.UpdateInstanceRequest, com.google.longrunning.Operation>
       getUpdateInstanceMethod() {
-    return getUpdateInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.UpdateInstanceRequest, com.google.longrunning.Operation>
-      getUpdateInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.UpdateInstanceRequest, com.google.longrunning.Operation>
         getUpdateInstanceMethod;
@@ -240,9 +201,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "UpdateInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -258,26 +217,18 @@ public final class CloudRedisGrpc {
     return getUpdateInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.ImportInstanceRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_INSTANCE = getImportInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.ImportInstanceRequest, com.google.longrunning.Operation>
       getImportInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportInstance",
+      requestType = com.google.cloud.redis.v1.ImportInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.ImportInstanceRequest, com.google.longrunning.Operation>
       getImportInstanceMethod() {
-    return getImportInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.ImportInstanceRequest, com.google.longrunning.Operation>
-      getImportInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.ImportInstanceRequest, com.google.longrunning.Operation>
         getImportInstanceMethod;
@@ -291,9 +242,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "ImportInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -309,26 +258,18 @@ public final class CloudRedisGrpc {
     return getImportInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.ExportInstanceRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_INSTANCE = getExportInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.ExportInstanceRequest, com.google.longrunning.Operation>
       getExportInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportInstance",
+      requestType = com.google.cloud.redis.v1.ExportInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.ExportInstanceRequest, com.google.longrunning.Operation>
       getExportInstanceMethod() {
-    return getExportInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.ExportInstanceRequest, com.google.longrunning.Operation>
-      getExportInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.ExportInstanceRequest, com.google.longrunning.Operation>
         getExportInstanceMethod;
@@ -342,9 +283,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "ExportInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -360,26 +299,18 @@ public final class CloudRedisGrpc {
     return getExportInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getFailoverInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.FailoverInstanceRequest, com.google.longrunning.Operation>
-      METHOD_FAILOVER_INSTANCE = getFailoverInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.FailoverInstanceRequest, com.google.longrunning.Operation>
       getFailoverInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "FailoverInstance",
+      requestType = com.google.cloud.redis.v1.FailoverInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.FailoverInstanceRequest, com.google.longrunning.Operation>
       getFailoverInstanceMethod() {
-    return getFailoverInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.FailoverInstanceRequest, com.google.longrunning.Operation>
-      getFailoverInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.FailoverInstanceRequest, com.google.longrunning.Operation>
         getFailoverInstanceMethod;
@@ -393,9 +324,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "FailoverInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "FailoverInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -413,26 +342,18 @@ public final class CloudRedisGrpc {
     return getFailoverInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.DeleteInstanceRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_INSTANCE = getDeleteInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.DeleteInstanceRequest, com.google.longrunning.Operation>
       getDeleteInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteInstance",
+      requestType = com.google.cloud.redis.v1.DeleteInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1.DeleteInstanceRequest, com.google.longrunning.Operation>
       getDeleteInstanceMethod() {
-    return getDeleteInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1.DeleteInstanceRequest, com.google.longrunning.Operation>
-      getDeleteInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1.DeleteInstanceRequest, com.google.longrunning.Operation>
         getDeleteInstanceMethod;
@@ -446,9 +367,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1.CloudRedis", "DeleteInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -466,19 +385,42 @@ public final class CloudRedisGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static CloudRedisStub newStub(io.grpc.Channel channel) {
-    return new CloudRedisStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<CloudRedisStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<CloudRedisStub>() {
+          @java.lang.Override
+          public CloudRedisStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CloudRedisStub(channel, callOptions);
+          }
+        };
+    return CloudRedisStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static CloudRedisBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new CloudRedisBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<CloudRedisBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<CloudRedisBlockingStub>() {
+          @java.lang.Override
+          public CloudRedisBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CloudRedisBlockingStub(channel, callOptions);
+          }
+        };
+    return CloudRedisBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static CloudRedisFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new CloudRedisFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<CloudRedisFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<CloudRedisFutureStub>() {
+          @java.lang.Override
+          public CloudRedisFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CloudRedisFutureStub(channel, callOptions);
+          }
+        };
+    return CloudRedisFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -517,7 +459,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.ListInstancesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1.ListInstancesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListInstancesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListInstancesMethod(), responseObserver);
     }
 
     /**
@@ -530,7 +472,7 @@ public final class CloudRedisGrpc {
     public void getInstance(
         com.google.cloud.redis.v1.GetInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1.Instance> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetInstanceMethod(), responseObserver);
     }
 
     /**
@@ -551,7 +493,7 @@ public final class CloudRedisGrpc {
     public void createInstance(
         com.google.cloud.redis.v1.CreateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateInstanceMethod(), responseObserver);
     }
 
     /**
@@ -567,7 +509,7 @@ public final class CloudRedisGrpc {
     public void updateInstance(
         com.google.cloud.redis.v1.UpdateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateInstanceMethod(), responseObserver);
     }
 
     /**
@@ -585,7 +527,7 @@ public final class CloudRedisGrpc {
     public void importInstance(
         com.google.cloud.redis.v1.ImportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportInstanceMethod(), responseObserver);
     }
 
     /**
@@ -601,7 +543,7 @@ public final class CloudRedisGrpc {
     public void exportInstance(
         com.google.cloud.redis.v1.ExportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportInstanceMethod(), responseObserver);
     }
 
     /**
@@ -615,7 +557,7 @@ public final class CloudRedisGrpc {
     public void failoverInstance(
         com.google.cloud.redis.v1.FailoverInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getFailoverInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getFailoverInstanceMethod(), responseObserver);
     }
 
     /**
@@ -629,57 +571,57 @@ public final class CloudRedisGrpc {
     public void deleteInstance(
         com.google.cloud.redis.v1.DeleteInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteInstanceMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListInstancesMethodHelper(),
+              getListInstancesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.ListInstancesRequest,
                       com.google.cloud.redis.v1.ListInstancesResponse>(
                       this, METHODID_LIST_INSTANCES)))
           .addMethod(
-              getGetInstanceMethodHelper(),
+              getGetInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.GetInstanceRequest,
                       com.google.cloud.redis.v1.Instance>(this, METHODID_GET_INSTANCE)))
           .addMethod(
-              getCreateInstanceMethodHelper(),
+              getCreateInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.CreateInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_INSTANCE)))
           .addMethod(
-              getUpdateInstanceMethodHelper(),
+              getUpdateInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.UpdateInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_UPDATE_INSTANCE)))
           .addMethod(
-              getImportInstanceMethodHelper(),
+              getImportInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.ImportInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_INSTANCE)))
           .addMethod(
-              getExportInstanceMethodHelper(),
+              getExportInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.ExportInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_INSTANCE)))
           .addMethod(
-              getFailoverInstanceMethodHelper(),
+              getFailoverInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.FailoverInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_FAILOVER_INSTANCE)))
           .addMethod(
-              getDeleteInstanceMethodHelper(),
+              getDeleteInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1.DeleteInstanceRequest,
@@ -706,11 +648,7 @@ public final class CloudRedisGrpc {
    * * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
    * </pre>
    */
-  public static final class CloudRedisStub extends io.grpc.stub.AbstractStub<CloudRedisStub> {
-    private CloudRedisStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class CloudRedisStub extends io.grpc.stub.AbstractAsyncStub<CloudRedisStub> {
     private CloudRedisStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -737,7 +675,7 @@ public final class CloudRedisGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1.ListInstancesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListInstancesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListInstancesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -753,7 +691,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.GetInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1.Instance> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -777,7 +715,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.CreateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -796,7 +734,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.UpdateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -817,7 +755,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.ImportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -836,7 +774,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.ExportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -853,7 +791,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.FailoverInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getFailoverInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getFailoverInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -870,7 +808,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1.DeleteInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -895,11 +833,7 @@ public final class CloudRedisGrpc {
    * </pre>
    */
   public static final class CloudRedisBlockingStub
-      extends io.grpc.stub.AbstractStub<CloudRedisBlockingStub> {
-    private CloudRedisBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<CloudRedisBlockingStub> {
     private CloudRedisBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -924,8 +858,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.cloud.redis.v1.ListInstancesResponse listInstances(
         com.google.cloud.redis.v1.ListInstancesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListInstancesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListInstancesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -937,8 +870,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.cloud.redis.v1.Instance getInstance(
         com.google.cloud.redis.v1.GetInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -958,8 +890,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation createInstance(
         com.google.cloud.redis.v1.CreateInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -974,8 +905,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation updateInstance(
         com.google.cloud.redis.v1.UpdateInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -992,8 +922,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation importInstance(
         com.google.cloud.redis.v1.ImportInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getImportInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getImportInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1008,8 +937,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation exportInstance(
         com.google.cloud.redis.v1.ExportInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1023,7 +951,7 @@ public final class CloudRedisGrpc {
     public com.google.longrunning.Operation failoverInstance(
         com.google.cloud.redis.v1.FailoverInstanceRequest request) {
       return blockingUnaryCall(
-          getChannel(), getFailoverInstanceMethodHelper(), getCallOptions(), request);
+          getChannel(), getFailoverInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1036,8 +964,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation deleteInstance(
         com.google.cloud.redis.v1.DeleteInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteInstanceMethod(), getCallOptions(), request);
     }
   }
 
@@ -1060,11 +987,7 @@ public final class CloudRedisGrpc {
    * </pre>
    */
   public static final class CloudRedisFutureStub
-      extends io.grpc.stub.AbstractStub<CloudRedisFutureStub> {
-    private CloudRedisFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<CloudRedisFutureStub> {
     private CloudRedisFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1090,7 +1013,7 @@ public final class CloudRedisGrpc {
             com.google.cloud.redis.v1.ListInstancesResponse>
         listInstances(com.google.cloud.redis.v1.ListInstancesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListInstancesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListInstancesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1103,7 +1026,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.redis.v1.Instance>
         getInstance(com.google.cloud.redis.v1.GetInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1124,7 +1047,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createInstance(com.google.cloud.redis.v1.CreateInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1140,7 +1063,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         updateInstance(com.google.cloud.redis.v1.UpdateInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1158,7 +1081,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importInstance(com.google.cloud.redis.v1.ImportInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1174,7 +1097,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportInstance(com.google.cloud.redis.v1.ExportInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1188,7 +1111,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         failoverInstance(com.google.cloud.redis.v1.FailoverInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getFailoverInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getFailoverInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1202,7 +1125,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteInstance(com.google.cloud.redis.v1.DeleteInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteInstanceMethod(), getCallOptions()), request);
     }
   }
 
@@ -1337,14 +1260,14 @@ public final class CloudRedisGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new CloudRedisFileDescriptorSupplier())
-                      .addMethod(getListInstancesMethodHelper())
-                      .addMethod(getGetInstanceMethodHelper())
-                      .addMethod(getCreateInstanceMethodHelper())
-                      .addMethod(getUpdateInstanceMethodHelper())
-                      .addMethod(getImportInstanceMethodHelper())
-                      .addMethod(getExportInstanceMethodHelper())
-                      .addMethod(getFailoverInstanceMethodHelper())
-                      .addMethod(getDeleteInstanceMethodHelper())
+                      .addMethod(getListInstancesMethod())
+                      .addMethod(getGetInstanceMethod())
+                      .addMethod(getCreateInstanceMethod())
+                      .addMethod(getUpdateInstanceMethod())
+                      .addMethod(getImportInstanceMethod())
+                      .addMethod(getExportInstanceMethod())
+                      .addMethod(getFailoverInstanceMethod())
+                      .addMethod(getDeleteInstanceMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-redis-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-redis-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.0.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/redis/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-redis-v1beta1/src/main/java/com/google/cloud/redis/v1beta1/CloudRedisGrpc.java
+++ b/grpc-google-cloud-redis-v1beta1/src/main/java/com/google/cloud/redis/v1beta1/CloudRedisGrpc.java
@@ -41,7 +41,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/redis/v1beta1/cloud_redis.proto")
 public final class CloudRedisGrpc {
 
@@ -50,30 +50,20 @@ public final class CloudRedisGrpc {
   public static final String SERVICE_NAME = "google.cloud.redis.v1beta1.CloudRedis";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListInstancesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.ListInstancesRequest,
-          com.google.cloud.redis.v1beta1.ListInstancesResponse>
-      METHOD_LIST_INSTANCES = getListInstancesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.ListInstancesRequest,
           com.google.cloud.redis.v1beta1.ListInstancesResponse>
       getListInstancesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListInstances",
+      requestType = com.google.cloud.redis.v1beta1.ListInstancesRequest.class,
+      responseType = com.google.cloud.redis.v1beta1.ListInstancesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.ListInstancesRequest,
           com.google.cloud.redis.v1beta1.ListInstancesResponse>
       getListInstancesMethod() {
-    return getListInstancesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.ListInstancesRequest,
-          com.google.cloud.redis.v1beta1.ListInstancesResponse>
-      getListInstancesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.ListInstancesRequest,
             com.google.cloud.redis.v1beta1.ListInstancesResponse>
@@ -88,9 +78,7 @@ public final class CloudRedisGrpc {
                           com.google.cloud.redis.v1beta1.ListInstancesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "ListInstances"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListInstances"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -108,30 +96,20 @@ public final class CloudRedisGrpc {
     return getListInstancesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.GetInstanceRequest,
-          com.google.cloud.redis.v1beta1.Instance>
-      METHOD_GET_INSTANCE = getGetInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.GetInstanceRequest,
           com.google.cloud.redis.v1beta1.Instance>
       getGetInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetInstance",
+      requestType = com.google.cloud.redis.v1beta1.GetInstanceRequest.class,
+      responseType = com.google.cloud.redis.v1beta1.Instance.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.GetInstanceRequest,
           com.google.cloud.redis.v1beta1.Instance>
       getGetInstanceMethod() {
-    return getGetInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.GetInstanceRequest,
-          com.google.cloud.redis.v1beta1.Instance>
-      getGetInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.GetInstanceRequest,
             com.google.cloud.redis.v1beta1.Instance>
@@ -146,9 +124,7 @@ public final class CloudRedisGrpc {
                           com.google.cloud.redis.v1beta1.Instance>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "GetInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -165,26 +141,18 @@ public final class CloudRedisGrpc {
     return getGetInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.CreateInstanceRequest, com.google.longrunning.Operation>
-      METHOD_CREATE_INSTANCE = getCreateInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.CreateInstanceRequest, com.google.longrunning.Operation>
       getCreateInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateInstance",
+      requestType = com.google.cloud.redis.v1beta1.CreateInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.CreateInstanceRequest, com.google.longrunning.Operation>
       getCreateInstanceMethod() {
-    return getCreateInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.CreateInstanceRequest, com.google.longrunning.Operation>
-      getCreateInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.CreateInstanceRequest, com.google.longrunning.Operation>
         getCreateInstanceMethod;
@@ -198,9 +166,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "CreateInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -217,26 +183,18 @@ public final class CloudRedisGrpc {
     return getCreateInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.UpdateInstanceRequest, com.google.longrunning.Operation>
-      METHOD_UPDATE_INSTANCE = getUpdateInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.UpdateInstanceRequest, com.google.longrunning.Operation>
       getUpdateInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateInstance",
+      requestType = com.google.cloud.redis.v1beta1.UpdateInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.UpdateInstanceRequest, com.google.longrunning.Operation>
       getUpdateInstanceMethod() {
-    return getUpdateInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.UpdateInstanceRequest, com.google.longrunning.Operation>
-      getUpdateInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.UpdateInstanceRequest, com.google.longrunning.Operation>
         getUpdateInstanceMethod;
@@ -250,9 +208,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "UpdateInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -269,26 +225,18 @@ public final class CloudRedisGrpc {
     return getUpdateInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpgradeInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.UpgradeInstanceRequest, com.google.longrunning.Operation>
-      METHOD_UPGRADE_INSTANCE = getUpgradeInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.UpgradeInstanceRequest, com.google.longrunning.Operation>
       getUpgradeInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpgradeInstance",
+      requestType = com.google.cloud.redis.v1beta1.UpgradeInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.UpgradeInstanceRequest, com.google.longrunning.Operation>
       getUpgradeInstanceMethod() {
-    return getUpgradeInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.UpgradeInstanceRequest, com.google.longrunning.Operation>
-      getUpgradeInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.UpgradeInstanceRequest, com.google.longrunning.Operation>
         getUpgradeInstanceMethod;
@@ -302,9 +250,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "UpgradeInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpgradeInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -322,26 +268,18 @@ public final class CloudRedisGrpc {
     return getUpgradeInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getImportInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.ImportInstanceRequest, com.google.longrunning.Operation>
-      METHOD_IMPORT_INSTANCE = getImportInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.ImportInstanceRequest, com.google.longrunning.Operation>
       getImportInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ImportInstance",
+      requestType = com.google.cloud.redis.v1beta1.ImportInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.ImportInstanceRequest, com.google.longrunning.Operation>
       getImportInstanceMethod() {
-    return getImportInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.ImportInstanceRequest, com.google.longrunning.Operation>
-      getImportInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.ImportInstanceRequest, com.google.longrunning.Operation>
         getImportInstanceMethod;
@@ -355,9 +293,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "ImportInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ImportInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -374,26 +310,18 @@ public final class CloudRedisGrpc {
     return getImportInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.ExportInstanceRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_INSTANCE = getExportInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.ExportInstanceRequest, com.google.longrunning.Operation>
       getExportInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportInstance",
+      requestType = com.google.cloud.redis.v1beta1.ExportInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.ExportInstanceRequest, com.google.longrunning.Operation>
       getExportInstanceMethod() {
-    return getExportInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.ExportInstanceRequest, com.google.longrunning.Operation>
-      getExportInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.ExportInstanceRequest, com.google.longrunning.Operation>
         getExportInstanceMethod;
@@ -407,9 +335,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "ExportInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -426,26 +352,18 @@ public final class CloudRedisGrpc {
     return getExportInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getFailoverInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.FailoverInstanceRequest, com.google.longrunning.Operation>
-      METHOD_FAILOVER_INSTANCE = getFailoverInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.FailoverInstanceRequest, com.google.longrunning.Operation>
       getFailoverInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "FailoverInstance",
+      requestType = com.google.cloud.redis.v1beta1.FailoverInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.FailoverInstanceRequest, com.google.longrunning.Operation>
       getFailoverInstanceMethod() {
-    return getFailoverInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.FailoverInstanceRequest, com.google.longrunning.Operation>
-      getFailoverInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.FailoverInstanceRequest,
             com.google.longrunning.Operation>
@@ -460,9 +378,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "FailoverInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "FailoverInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -480,26 +396,18 @@ public final class CloudRedisGrpc {
     return getFailoverInstanceMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteInstanceMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.DeleteInstanceRequest, com.google.longrunning.Operation>
-      METHOD_DELETE_INSTANCE = getDeleteInstanceMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.DeleteInstanceRequest, com.google.longrunning.Operation>
       getDeleteInstanceMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteInstance",
+      requestType = com.google.cloud.redis.v1beta1.DeleteInstanceRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.redis.v1beta1.DeleteInstanceRequest, com.google.longrunning.Operation>
       getDeleteInstanceMethod() {
-    return getDeleteInstanceMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.redis.v1beta1.DeleteInstanceRequest, com.google.longrunning.Operation>
-      getDeleteInstanceMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.redis.v1beta1.DeleteInstanceRequest, com.google.longrunning.Operation>
         getDeleteInstanceMethod;
@@ -513,9 +421,7 @@ public final class CloudRedisGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.redis.v1beta1.CloudRedis", "DeleteInstance"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteInstance"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -534,19 +440,42 @@ public final class CloudRedisGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static CloudRedisStub newStub(io.grpc.Channel channel) {
-    return new CloudRedisStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<CloudRedisStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<CloudRedisStub>() {
+          @java.lang.Override
+          public CloudRedisStub newStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CloudRedisStub(channel, callOptions);
+          }
+        };
+    return CloudRedisStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static CloudRedisBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new CloudRedisBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<CloudRedisBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<CloudRedisBlockingStub>() {
+          @java.lang.Override
+          public CloudRedisBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CloudRedisBlockingStub(channel, callOptions);
+          }
+        };
+    return CloudRedisBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static CloudRedisFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new CloudRedisFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<CloudRedisFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<CloudRedisFutureStub>() {
+          @java.lang.Override
+          public CloudRedisFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new CloudRedisFutureStub(channel, callOptions);
+          }
+        };
+    return CloudRedisFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -585,7 +514,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.ListInstancesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1beta1.ListInstancesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListInstancesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListInstancesMethod(), responseObserver);
     }
 
     /**
@@ -598,7 +527,7 @@ public final class CloudRedisGrpc {
     public void getInstance(
         com.google.cloud.redis.v1beta1.GetInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1beta1.Instance> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetInstanceMethod(), responseObserver);
     }
 
     /**
@@ -619,7 +548,7 @@ public final class CloudRedisGrpc {
     public void createInstance(
         com.google.cloud.redis.v1beta1.CreateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateInstanceMethod(), responseObserver);
     }
 
     /**
@@ -635,7 +564,7 @@ public final class CloudRedisGrpc {
     public void updateInstance(
         com.google.cloud.redis.v1beta1.UpdateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateInstanceMethod(), responseObserver);
     }
 
     /**
@@ -649,7 +578,7 @@ public final class CloudRedisGrpc {
     public void upgradeInstance(
         com.google.cloud.redis.v1beta1.UpgradeInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpgradeInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpgradeInstanceMethod(), responseObserver);
     }
 
     /**
@@ -667,7 +596,7 @@ public final class CloudRedisGrpc {
     public void importInstance(
         com.google.cloud.redis.v1beta1.ImportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getImportInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getImportInstanceMethod(), responseObserver);
     }
 
     /**
@@ -683,7 +612,7 @@ public final class CloudRedisGrpc {
     public void exportInstance(
         com.google.cloud.redis.v1beta1.ExportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportInstanceMethod(), responseObserver);
     }
 
     /**
@@ -697,7 +626,7 @@ public final class CloudRedisGrpc {
     public void failoverInstance(
         com.google.cloud.redis.v1beta1.FailoverInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getFailoverInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getFailoverInstanceMethod(), responseObserver);
     }
 
     /**
@@ -711,63 +640,63 @@ public final class CloudRedisGrpc {
     public void deleteInstance(
         com.google.cloud.redis.v1beta1.DeleteInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteInstanceMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteInstanceMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getListInstancesMethodHelper(),
+              getListInstancesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.ListInstancesRequest,
                       com.google.cloud.redis.v1beta1.ListInstancesResponse>(
                       this, METHODID_LIST_INSTANCES)))
           .addMethod(
-              getGetInstanceMethodHelper(),
+              getGetInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.GetInstanceRequest,
                       com.google.cloud.redis.v1beta1.Instance>(this, METHODID_GET_INSTANCE)))
           .addMethod(
-              getCreateInstanceMethodHelper(),
+              getCreateInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.CreateInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_CREATE_INSTANCE)))
           .addMethod(
-              getUpdateInstanceMethodHelper(),
+              getUpdateInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.UpdateInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_UPDATE_INSTANCE)))
           .addMethod(
-              getUpgradeInstanceMethodHelper(),
+              getUpgradeInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.UpgradeInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_UPGRADE_INSTANCE)))
           .addMethod(
-              getImportInstanceMethodHelper(),
+              getImportInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.ImportInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_IMPORT_INSTANCE)))
           .addMethod(
-              getExportInstanceMethodHelper(),
+              getExportInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.ExportInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_INSTANCE)))
           .addMethod(
-              getFailoverInstanceMethodHelper(),
+              getFailoverInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.FailoverInstanceRequest,
                       com.google.longrunning.Operation>(this, METHODID_FAILOVER_INSTANCE)))
           .addMethod(
-              getDeleteInstanceMethodHelper(),
+              getDeleteInstanceMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.redis.v1beta1.DeleteInstanceRequest,
@@ -794,11 +723,7 @@ public final class CloudRedisGrpc {
    * * `projects/redpepper-1290/locations/us-central1/instances/my-redis`
    * </pre>
    */
-  public static final class CloudRedisStub extends io.grpc.stub.AbstractStub<CloudRedisStub> {
-    private CloudRedisStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class CloudRedisStub extends io.grpc.stub.AbstractAsyncStub<CloudRedisStub> {
     private CloudRedisStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -825,7 +750,7 @@ public final class CloudRedisGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1beta1.ListInstancesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListInstancesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getListInstancesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -841,7 +766,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.GetInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.redis.v1beta1.Instance> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getGetInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -865,7 +790,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.CreateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getCreateInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -884,7 +809,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.UpdateInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpdateInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -901,7 +826,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.UpgradeInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpgradeInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getUpgradeInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -922,7 +847,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.ImportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getImportInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getImportInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -941,7 +866,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.ExportInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -958,7 +883,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.FailoverInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getFailoverInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getFailoverInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -975,7 +900,7 @@ public final class CloudRedisGrpc {
         com.google.cloud.redis.v1beta1.DeleteInstanceRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteInstanceMethodHelper(), getCallOptions()),
+          getChannel().newCall(getDeleteInstanceMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -1000,11 +925,7 @@ public final class CloudRedisGrpc {
    * </pre>
    */
   public static final class CloudRedisBlockingStub
-      extends io.grpc.stub.AbstractStub<CloudRedisBlockingStub> {
-    private CloudRedisBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<CloudRedisBlockingStub> {
     private CloudRedisBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1029,8 +950,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.cloud.redis.v1beta1.ListInstancesResponse listInstances(
         com.google.cloud.redis.v1beta1.ListInstancesRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getListInstancesMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListInstancesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1042,8 +962,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.cloud.redis.v1beta1.Instance getInstance(
         com.google.cloud.redis.v1beta1.GetInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getGetInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1063,8 +982,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation createInstance(
         com.google.cloud.redis.v1beta1.CreateInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1079,8 +997,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation updateInstance(
         com.google.cloud.redis.v1beta1.UpdateInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1093,8 +1010,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation upgradeInstance(
         com.google.cloud.redis.v1beta1.UpgradeInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpgradeInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpgradeInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1111,8 +1027,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation importInstance(
         com.google.cloud.redis.v1beta1.ImportInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getImportInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getImportInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1127,8 +1042,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation exportInstance(
         com.google.cloud.redis.v1beta1.ExportInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1142,7 +1056,7 @@ public final class CloudRedisGrpc {
     public com.google.longrunning.Operation failoverInstance(
         com.google.cloud.redis.v1beta1.FailoverInstanceRequest request) {
       return blockingUnaryCall(
-          getChannel(), getFailoverInstanceMethodHelper(), getCallOptions(), request);
+          getChannel(), getFailoverInstanceMethod(), getCallOptions(), request);
     }
 
     /**
@@ -1155,8 +1069,7 @@ public final class CloudRedisGrpc {
      */
     public com.google.longrunning.Operation deleteInstance(
         com.google.cloud.redis.v1beta1.DeleteInstanceRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteInstanceMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteInstanceMethod(), getCallOptions(), request);
     }
   }
 
@@ -1179,11 +1092,7 @@ public final class CloudRedisGrpc {
    * </pre>
    */
   public static final class CloudRedisFutureStub
-      extends io.grpc.stub.AbstractStub<CloudRedisFutureStub> {
-    private CloudRedisFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<CloudRedisFutureStub> {
     private CloudRedisFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -1209,7 +1118,7 @@ public final class CloudRedisGrpc {
             com.google.cloud.redis.v1beta1.ListInstancesResponse>
         listInstances(com.google.cloud.redis.v1beta1.ListInstancesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getListInstancesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getListInstancesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1223,7 +1132,7 @@ public final class CloudRedisGrpc {
             com.google.cloud.redis.v1beta1.Instance>
         getInstance(com.google.cloud.redis.v1beta1.GetInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getGetInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getGetInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1244,7 +1153,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         createInstance(com.google.cloud.redis.v1beta1.CreateInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1260,7 +1169,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         updateInstance(com.google.cloud.redis.v1beta1.UpdateInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1274,7 +1183,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         upgradeInstance(com.google.cloud.redis.v1beta1.UpgradeInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpgradeInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpgradeInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1292,7 +1201,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         importInstance(com.google.cloud.redis.v1beta1.ImportInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getImportInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getImportInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1308,7 +1217,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportInstance(com.google.cloud.redis.v1beta1.ExportInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1322,7 +1231,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         failoverInstance(com.google.cloud.redis.v1beta1.FailoverInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getFailoverInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getFailoverInstanceMethod(), getCallOptions()), request);
     }
 
     /**
@@ -1336,7 +1245,7 @@ public final class CloudRedisGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         deleteInstance(com.google.cloud.redis.v1beta1.DeleteInstanceRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteInstanceMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteInstanceMethod(), getCallOptions()), request);
     }
   }
 
@@ -1478,15 +1387,15 @@ public final class CloudRedisGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new CloudRedisFileDescriptorSupplier())
-                      .addMethod(getListInstancesMethodHelper())
-                      .addMethod(getGetInstanceMethodHelper())
-                      .addMethod(getCreateInstanceMethodHelper())
-                      .addMethod(getUpdateInstanceMethodHelper())
-                      .addMethod(getUpgradeInstanceMethodHelper())
-                      .addMethod(getImportInstanceMethodHelper())
-                      .addMethod(getExportInstanceMethodHelper())
-                      .addMethod(getFailoverInstanceMethodHelper())
-                      .addMethod(getDeleteInstanceMethodHelper())
+                      .addMethod(getListInstancesMethod())
+                      .addMethod(getGetInstanceMethod())
+                      .addMethod(getCreateInstanceMethod())
+                      .addMethod(getUpdateInstanceMethod())
+                      .addMethod(getUpgradeInstanceMethod())
+                      .addMethod(getImportInstanceMethod())
+                      .addMethod(getExportInstanceMethod())
+                      .addMethod(getFailoverInstanceMethod())
+                      .addMethod(getDeleteInstanceMethod())
                       .build();
         }
       }

--- a/synth.py
+++ b/synth.py
@@ -14,23 +14,16 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
-
-gapic = gcp.GAPICGenerator()
 
 service = 'redis'
 versions = ['v1', 'v1beta1']
-config_pattern = '/google/cloud/redis/artman_redis_{version}.yaml'
 
 for version in versions:
-  java.gapic_library(
-    service=service,
-    version=version,
-    config_pattern=config_pattern,
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
+  library = java.bazel_library(
+      service=service,
+      version=version,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
 
 java.common_templates(excludes=[


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)
