### PR TITLE
fix: flakey integration tests

### DIFF
--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.redis.v1.CloudRedisClient;
+import com.google.cloud.redis.v1.CloudRedisSettings;
 import com.google.cloud.redis.v1.Instance;
 import com.google.cloud.redis.v1.InstanceName;
 import com.google.cloud.redis.v1.LocationName;
@@ -34,6 +35,7 @@ import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.threeten.bp.Duration;
 
 public class ITSystemTest {
 
@@ -53,7 +55,18 @@ public class ITSystemTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    client = CloudRedisClient.create();
+    CloudRedisSettings.Builder cloudRedisSettingsBuilder = CloudRedisSettings.newBuilder();
+    cloudRedisSettingsBuilder
+        .getInstanceSettings()
+        .setRetrySettings(
+            cloudRedisSettingsBuilder
+                .getInstanceSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(60))
+                .build());
+    CloudRedisSettings cloudRedisSettings = cloudRedisSettingsBuilder.build();
+    client = CloudRedisClient.create(cloudRedisSettings);
     /* Creates a Redis instance based on the specified tier and memory size. */
     Instance instance =
         Instance.newBuilder()

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
@@ -63,7 +63,7 @@ public class ITSystemTest {
                 .getInstanceSettings()
                 .getRetrySettings()
                 .toBuilder()
-                .setTotalTimeout(Duration.ofSeconds(60))
+                .setTotalTimeout(Duration.ofSeconds(900))
                 .build());
     CloudRedisSettings cloudRedisSettings = cloudRedisSettingsBuilder.build();
     client = CloudRedisClient.create(cloudRedisSettings);

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
@@ -18,13 +18,11 @@ package com.google.cloud.redis.v1.it;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.redis.v1.CloudRedisClient;
 import com.google.cloud.redis.v1.Instance;
 import com.google.cloud.redis.v1.InstanceName;
 import com.google.cloud.redis.v1.LocationName;
-import com.google.cloud.redis.v1.OperationMetadata;
 import com.google.cloud.redis.v1.UpdateInstanceRequest;
 import com.google.common.collect.Lists;
 import com.google.protobuf.FieldMask;
@@ -105,14 +103,7 @@ public class ITSystemTest {
             .build();
     UpdateInstanceRequest updateInstanceRequest =
         UpdateInstanceRequest.newBuilder().setInstance(instance).setUpdateMask(updateMask).build();
-    OperationFuture<Instance, OperationMetadata> future =
-        client.updateInstanceAsync(updateInstanceRequest);
-    while (true) {
-      if (future.isDone()) {
-        Instance updatedInstance = future.get();
-        assertEquals(memorySizeGb, updatedInstance.getMemorySizeGb());
-        break;
-      }
-    }
+    Instance actualInstance = client.updateInstanceAsync(updateInstanceRequest).get();
+    assertEquals(memorySizeGb, actualInstance.getMemorySizeGb());
   }
 }

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1/it/ITSystemTest.java
@@ -18,11 +18,13 @@ package com.google.cloud.redis.v1.it;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.redis.v1.CloudRedisClient;
 import com.google.cloud.redis.v1.Instance;
 import com.google.cloud.redis.v1.InstanceName;
 import com.google.cloud.redis.v1.LocationName;
+import com.google.cloud.redis.v1.OperationMetadata;
 import com.google.cloud.redis.v1.UpdateInstanceRequest;
 import com.google.common.collect.Lists;
 import com.google.protobuf.FieldMask;
@@ -103,7 +105,14 @@ public class ITSystemTest {
             .build();
     UpdateInstanceRequest updateInstanceRequest =
         UpdateInstanceRequest.newBuilder().setInstance(instance).setUpdateMask(updateMask).build();
-    Instance actualInstance = client.updateInstanceAsync(updateInstanceRequest).get();
-    assertEquals(memorySizeGb, actualInstance.getMemorySizeGb());
+    OperationFuture<Instance, OperationMetadata> future =
+        client.updateInstanceAsync(updateInstanceRequest);
+    while (true) {
+      if (future.isDone()) {
+        Instance updatedInstance = future.get();
+        assertEquals(memorySizeGb, updatedInstance.getMemorySizeGb());
+        break;
+      }
+    }
   }
 }

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.redis.v1beta1.CloudRedisClient;
+import com.google.cloud.redis.v1beta1.CloudRedisSettings;
 import com.google.cloud.redis.v1beta1.Instance;
 import com.google.cloud.redis.v1beta1.InstanceName;
 import com.google.cloud.redis.v1beta1.LocationName;
@@ -34,6 +35,7 @@ import java.util.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.threeten.bp.Duration;
 
 public class ITSystemTest {
 
@@ -53,7 +55,18 @@ public class ITSystemTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    client = CloudRedisClient.create();
+    CloudRedisSettings.Builder cloudRedisSettingsBuilder = CloudRedisSettings.newBuilder();
+    cloudRedisSettingsBuilder
+        .getInstanceSettings()
+        .setRetrySettings(
+            cloudRedisSettingsBuilder
+                .getInstanceSettings()
+                .getRetrySettings()
+                .toBuilder()
+                .setTotalTimeout(Duration.ofSeconds(60))
+                .build());
+    CloudRedisSettings cloudRedisSettings = cloudRedisSettingsBuilder.build();
+    client = CloudRedisClient.create(cloudRedisSettings);
     /* Creates a Redis instance based on the specified tier and memory size. */
     Instance instance =
         Instance.newBuilder()

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.redis.v1beta1.it;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.redis.v1beta1.CloudRedisClient;
 import com.google.cloud.redis.v1beta1.Instance;
@@ -25,6 +26,7 @@ import com.google.cloud.redis.v1beta1.InstanceName;
 import com.google.cloud.redis.v1beta1.LocationName;
 import com.google.cloud.redis.v1beta1.UpdateInstanceRequest;
 import com.google.common.collect.Lists;
+import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import java.util.Arrays;
 import java.util.List;
@@ -103,7 +105,13 @@ public class ITSystemTest {
             .build();
     UpdateInstanceRequest updateInstanceRequest =
         UpdateInstanceRequest.newBuilder().setInstance(instance).setUpdateMask(updateMask).build();
-    Instance actualInstance = client.updateInstanceAsync(updateInstanceRequest).get();
-    assertEquals(memorySizeGb, actualInstance.getMemorySizeGb());
+    OperationFuture<Instance, Any> future = client.updateInstanceAsync(updateInstanceRequest);
+    while (true) {
+      if (future.isDone()) {
+        Instance updatedInstance = future.get();
+        assertEquals(memorySizeGb, updatedInstance.getMemorySizeGb());
+        break;
+      }
+    }
   }
 }

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
@@ -63,7 +63,7 @@ public class ITSystemTest {
                 .getInstanceSettings()
                 .getRetrySettings()
                 .toBuilder()
-                .setTotalTimeout(Duration.ofSeconds(60))
+                .setTotalTimeout(Duration.ofSeconds(900))
                 .build());
     CloudRedisSettings cloudRedisSettings = cloudRedisSettingsBuilder.build();
     client = CloudRedisClient.create(cloudRedisSettings);

--- a/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
+++ b/google-cloud-redis/src/test/java/com/google/cloud/redis/v1beta1/it/ITSystemTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.redis.v1beta1.it;
 
 import static org.junit.Assert.assertEquals;
 
-import com.google.api.gax.longrunning.OperationFuture;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.redis.v1beta1.CloudRedisClient;
 import com.google.cloud.redis.v1beta1.Instance;
@@ -26,7 +25,6 @@ import com.google.cloud.redis.v1beta1.InstanceName;
 import com.google.cloud.redis.v1beta1.LocationName;
 import com.google.cloud.redis.v1beta1.UpdateInstanceRequest;
 import com.google.common.collect.Lists;
-import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import java.util.Arrays;
 import java.util.List;
@@ -105,13 +103,7 @@ public class ITSystemTest {
             .build();
     UpdateInstanceRequest updateInstanceRequest =
         UpdateInstanceRequest.newBuilder().setInstance(instance).setUpdateMask(updateMask).build();
-    OperationFuture<Instance, Any> future = client.updateInstanceAsync(updateInstanceRequest);
-    while (true) {
-      if (future.isDone()) {
-        Instance updatedInstance = future.get();
-        assertEquals(memorySizeGb, updatedInstance.getMemorySizeGb());
-        break;
-      }
-    }
+    Instance actualInstance = client.updateInstanceAsync(updateInstanceRequest).get();
+    assertEquals(memorySizeGb, actualInstance.getMemorySizeGb());
   }
 }


### PR DESCRIPTION
Use `CloudRedisSettings `to create `CloudRedisClient `by Increasing `RetrySettings.setTotalTimeout()` value to `PT15M(900 seconds)` instead of default `PT10M(600 seconds)` to prevent flaky failures.

**Flaky Failure :**
```
SEVERE: Exception while executing runnable io.grpc.internal.ClientCallImpl$1DeadlineExceededNotifyApplicationTimer@5db63edb
java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask@56ea411 rejected from java.util.concurrent.ScheduledThreadPoolExecutor@6d7a394[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 109]
	at java.util.concurrent.ThreadPoolExecutor$AbortPolicy.rejectedExecution(ThreadPoolExecutor.java:2063)
	at java.util.concurrent.ThreadPoolExecutor.reject(ThreadPoolExecutor.java:830)
	at java.util.concurrent.ScheduledThreadPoolExecutor.delayedExecute(ScheduledThreadPoolExecutor.java:326)
	at java.util.concurrent.ScheduledThreadPoolExecutor.schedule(ScheduledThreadPoolExecutor.java:533)
	at java.util.concurrent.ScheduledThreadPoolExecutor.execute(ScheduledThreadPoolExecutor.java:622)
	at io.grpc.internal.SerializingExecutor.schedule(SerializingExecutor.java:93)
	at io.grpc.internal.SerializingExecutor.execute(SerializingExecutor.java:86)
	at io.grpc.internal.ClientCallImpl.executeCloseObserverInContext(ClientCallImpl.java:420)
	at io.grpc.internal.ClientCallImpl.delayedCancelOnDeadlineExceeded(ClientCallImpl.java:405)
	at io.grpc.internal.ClientCallImpl.access$100(ClientCallImpl.java:66)
	at io.grpc.internal.ClientCallImpl$1DeadlineExceededNotifyApplicationTimer.run(ClientCallImpl.java:355)
	at io.grpc.internal.LogExceptionRunnable.run(LogExceptionRunnable.java:43)
	at io.grpc.netty.shaded.io.netty.util.concurrent.PromiseTask.runTask(PromiseTask.java:98)
	at io.grpc.netty.shaded.io.netty.util.concurrent.ScheduledFutureTask.run(ScheduledFutureTask.java:170)
	at io.grpc.netty.shaded.io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:164)
	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:472)
	at io.grpc.netty.shaded.io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:384)
	at io.grpc.netty.shaded.io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:989)
	at io.grpc.netty.shaded.io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
	at io.grpc.netty.shaded.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:748)
```
Fixes #118 
